### PR TITLE
Remove unnecessary return statement

### DIFF
--- a/app/controllers/whenbot_controller.rb
+++ b/app/controllers/whenbot_controller.rb
@@ -24,6 +24,6 @@ class WhenbotController < ApplicationController
     response[:type]       ||= :json
     response[:headers]    ||= ''
     response[:body]       ||= 'Success'
-    return response
+    response
   end
 end


### PR DESCRIPTION
As suggested by @M7 on ottawaruby/whenbot#25 I removed the return statement to fit more with the ruby-esque coding style.
